### PR TITLE
MongoEngine connection bridge.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,18 @@ language: python
 sudo: false
 cache: pip
 
+addons:
+  apt:
+    sources:
+      - mongodb-upstart
+      - mongodb-3.2-precise
+    packages:
+      - mongodb-org-server
+      - mongodb-org-shell
+
+services:
+  - mongodb
+
 branches:
   except:
       - /^[^/]+/.+$/

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ addopts =
 	-l -r fEsxw --flakes --no-cov-on-fail --durations=5 --color=yes
 	--cov-report term-missing --cov-report html --cov-report xml
 	--cov web.db.dbapi
+	--cov web.db.me
 	--cov web.ext.db
 	test
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ tests_require = [
 		'pytest-cov',  # coverage reporting
 		'pytest-flakes',  # syntax validation
 		'pytest-capturelog',  # log capture
+		'mongoengine',  # database connector
 	]
 
 

--- a/test/test_mongoengine.py
+++ b/test/test_mongoengine.py
@@ -4,17 +4,16 @@ from __future__ import unicode_literals
 
 import pytest
 
+from pymongo.collection import Collection
+from mongoengine import Document, StringField
+
 from web.core.context import Context
 from web.db.me import MongoEngineConnection
 from web.ext.db import DatabaseExtension
 
-from mongoengine import Document, StringField
-
-
 
 class Sample(Document):
 	name = StringField()
-
 
 
 @pytest.fixture
@@ -31,9 +30,29 @@ def db():
 	db.stop(ctx)
 
 
-
 class TestMongoEngineConnection(object):
 	def test_connection_lifecycle(self, db):
 		assert db._connection
-
+	
+	def test_private_is_protected(self, db):
+		with pytest.raises(AttributeError):
+			db._private
+		
+		with pytest.raises(KeyError):
+			db['_private']
+	
+	def test_collection_access(self, db):
+		assert isinstance(db.hello, Collection)
+		assert isinstance(db['hello'], Collection)
+	
+	def test_document_access(self, db):
+		assert db.Sample is Sample
+		assert db['Sample'] is Sample
+	
+	def test_missing_document(self, db):
+		with pytest.raises(AttributeError):
+			db.Example
+		
+		with pytest.raises(KeyError):
+			db['Example']
 

--- a/test/test_mongoengine.py
+++ b/test/test_mongoengine.py
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+from __future__ import unicode_literals
+
+from web.db.me import MongoEngineProxy, MongoEngineDBConnection
+
+MongoEngineProxy
+MongoEngineDBConnection
+

--- a/test/test_mongoengine.py
+++ b/test/test_mongoengine.py
@@ -2,8 +2,38 @@
 
 from __future__ import unicode_literals
 
-from web.db.me import MongoEngineProxy, MongoEngineDBConnection
+import pytest
 
-MongoEngineProxy
-MongoEngineDBConnection
+from web.core.context import Context
+from web.db.me import MongoEngineConnection
+from web.ext.db import DatabaseExtension
+
+from mongoengine import Document, StringField
+
+
+
+class Sample(Document):
+	name = StringField()
+
+
+
+@pytest.fixture
+def db():
+	"""Get the mid-request context.db object."""
+	
+	ctx = Context()
+	db = DatabaseExtension(MongoEngineConnection('mongodb://localhost/test'))
+	db.start(ctx)
+	db.prepare(ctx)
+	
+	yield ctx.db.default
+	
+	db.stop(ctx)
+
+
+
+class TestMongoEngineConnection(object):
+	def test_connection_lifecycle(self, db):
+		assert db._connection
+
 

--- a/web/db/me.py
+++ b/web/db/me.py
@@ -3,7 +3,8 @@
 import re
 
 try:
-	from mongoengine import connect, disconnect
+	from mongoengine import connect
+	from mongoengine.connection import disconnect
 	from mongoengine.base import get_document
 	from mongoengine.errors import NotRegistered
 except ImportError:

--- a/web/db/me.py
+++ b/web/db/me.py
@@ -53,8 +53,6 @@ class MongoEngineProxy(object):
 		raise KeyError()
 
 
-
-
 class MongoEngineConnection(object):
 	"""WebCore DBExtension interface for projects utilizing MongoEngine.
 	
@@ -101,6 +99,4 @@ class MongoEngineConnection(object):
 		
 		disconnect(self.name)
 		del self.connection
-	
-
 

--- a/web/db/me.py
+++ b/web/db/me.py
@@ -7,7 +7,7 @@ try:
 	from mongoengine.connection import disconnect
 	from mongoengine.base import get_document
 	from mongoengine.errors import NotRegistered
-except ImportError:
+except ImportError:  # pragma: no cover
 	raise ImportError('Unable to import mongoengine; pip install mongoengine to fix this.')
 
 

--- a/web/db/me.py
+++ b/web/db/me.py
@@ -21,9 +21,7 @@ class MongoEngineProxy(object):
 	"""Lazily load MongoEngine Document subclasses from its registry.
 	
 	Because MongoEngine supports the concept of multiple named connections, if you make multiple
-	`MongoEngineDBConnection` connections the same Document subclasses are made available across all-
-	the registry is common-but accessing via this proxy will bind to the specific connection being
-	dereferenced.
+	`MongoEngineDBConnection` connections the same Document subclasses are made available across all.
 	"""
 	
 	def __init__(self, connection):


### PR DESCRIPTION
MongoEngine has its own named multiple database support. We can bridge this into a context structure using a small proxy object which uses MongoEngine's `get_document` helper to load documents during attribute or mapping access.  Remember to bind the document to the selected connection before returning.
